### PR TITLE
Fix handling for buffers with . when using markers

### DIFF
--- a/fish.py
+++ b/fish.py
@@ -775,7 +775,7 @@ def fish_modifier_in_notice_cb(data, modifier, server_name, string):
         return string
 
     target = "%s/%s" % (server_name, match.group(2))
-    targetl = ("%s/%s" % (server_name, match.group(2))).lower()
+    targetl = target.lower()
     buffer = weechat.info_get("irc_buffer", "%s,%s" % (
             server_name, match.group(2)))
 
@@ -867,7 +867,7 @@ def fish_modifier_in_privmsg_cb(data, modifier, server_name, string):
     else:
         dest = match.group(3)
     target = "%s/%s" % (server_name, dest)
-    targetl = ("%s/%s" % (server_name, dest)).lower()
+    targetl = target.lower()
     buffer = weechat.info_get("irc_buffer", "%s,%s" % (server_name, dest))
 
     if not match.group(6):
@@ -908,7 +908,7 @@ def fish_modifier_in_topic_cb(data, modifier, server_name, string):
         return string
 
     target = "%s/%s" % (server_name, match.group(2))
-    targetl = ("%s/%s" % (server_name, match.group(2))).lower()
+    targetl = target.lower()
     buffer = weechat.info_get("irc_buffer", "%s,%s" % (server_name,
             match.group(2)))
 
@@ -939,7 +939,7 @@ def fish_modifier_in_332_cb(data, modifier, server_name, string):
         return string
 
     target = "%s/%s" % (server_name, match.group(2))
-    targetl = ("%s/%s" % (server_name, match.group(2))).lower()
+    targetl = target.lower()
     buffer = weechat.info_get("irc_buffer", "%s,%s" % (server_name,
             match.group(2)))
 
@@ -971,7 +971,7 @@ def fish_modifier_out_privmsg_cb(data, modifier, server_name, string):
         return string
 
     target = "%s/%s" % (server_name, match.group(2))
-    targetl = ("%s/%s" % (server_name, match.group(2))).lower()
+    targetl = target.lower()
     buffer = weechat.info_get("irc_buffer", "%s,%s" % (server_name,
             match.group(2)))
 
@@ -1002,7 +1002,7 @@ def fish_modifier_out_topic_cb(data, modifier, server_name, string):
         return string
 
     target = "%s/%s" % (server_name, match.group(2))
-    targetl = ("%s/%s" % (server_name, match.group(2))).lower()
+    targetl = target.lower()
     buffer = weechat.info_get("irc_buffer", "%s,%s" % (server_name,
             match.group(2)))
 
@@ -1027,12 +1027,14 @@ def fish_modifier_input_text(data, modifier, server_name, string):
     if weechat.string_is_command_char(string):
         return string
     buffer = weechat.current_buffer()
-    name = weechat.buffer_get_string(buffer, "name")
-    target = name.replace(".", "/")
+    target = "%s/%s" % (
+            weechat.buffer_get_string(buffer, "localvar_server"),
+            weechat.buffer_get_string(buffer, "localvar_channel")
+        )
     targetl = target.lower()
     if targetl not in fish_keys:
         return string
-    return "%s" % (fish_msg_w_marker(string))
+    return fish_msg_w_marker(string)
 
 
 def fish_unload_cb():
@@ -1108,7 +1110,7 @@ def fish_cmd_blowkey(data, buffer, args):
             argv2eol = args[args.find(" ") +1:]
 
     target = "%s/%s" % (server_name, target_user)
-    targetl = ("%s/%s" % (server_name, target_user)).lower()
+    targetl = target.lower()
 
     if argv[0] == "set":
         fish_keys[targetl] = argv2eol

--- a/fish.py
+++ b/fish.py
@@ -914,7 +914,6 @@ def fish_modifier_in_topic_cb(data, modifier, server_name, string):
 
     if targetl not in fish_keys or not match.group(4):
         fish_announce_unencrypted(buffer, target)
-
         return string
 
     if targetl not in fish_cyphers:
@@ -945,7 +944,6 @@ def fish_modifier_in_332_cb(data, modifier, server_name, string):
 
     if targetl not in fish_keys or not match.group(4):
         fish_announce_unencrypted(buffer, target)
-
         return string
 
     if targetl not in fish_cyphers:
@@ -977,7 +975,6 @@ def fish_modifier_out_privmsg_cb(data, modifier, server_name, string):
 
     if targetl not in fish_keys:
         fish_announce_unencrypted(buffer, target)
-
         return string
 
     if targetl not in fish_cyphers:
@@ -1008,7 +1005,6 @@ def fish_modifier_out_topic_cb(data, modifier, server_name, string):
 
     if targetl not in fish_keys:
         fish_announce_unencrypted(buffer, target)
-
         return string
 
     if targetl not in fish_cyphers:
@@ -1023,10 +1019,9 @@ def fish_modifier_out_topic_cb(data, modifier, server_name, string):
     return "%s%s" % (match.group(1), cypher)
 
 
-def fish_modifier_input_text(data, modifier, server_name, string):
+def fish_modifier_input_text(data, modifier, buffer, string):
     if weechat.string_is_command_char(string):
         return string
-    buffer = weechat.current_buffer()
     target = "%s/%s" % (
             weechat.buffer_get_string(buffer, "localvar_server"),
             weechat.buffer_get_string(buffer, "localvar_channel")


### PR DESCRIPTION
The previous code made too many assumptions about buffer names.
Keys are stored in a `server/channel` or `server/nick` fashion which is
not generally a problem. But weechat-internal the buffers are stored as
`server.nick` or `server.#channel`.
The previous code used the weechat buffername and replaced . to / to
build the identifier for keys in this plugin. Problem is, if you have a
buffername that contains a . e.g. `my.server` or a channel like
`#.chan` you'd end up with a reference to a key that does not exist
(`server/#/chan`)
The only place this is actually a problem in is in the marker handling.
The code would due to not finding the key reference assume user input
would not need the marker (`fish_modifier_input_text`) and thus not add
it to a outgoing message.
In `fish_modifier_out_privmsg_cb` on the other hand the logic is
different and would correctly determine that the text should be
encrypted and call `fish_msg_wo_marker` which based on the settings
would then remove the marker from the message before encrypting it and
sending it to the server.
Since the marker was never added on client side in the first place it
instead removes parts of the outgoing message based on the marker
length and thus cuts off the outgoing message. For the user the message
is displayed correctly but for other users the message would be cut and
missing as many chars as the marker length would've been.