### PR TITLE
support more ircv3 extensions

### DIFF
--- a/fish.py
+++ b/fish.py
@@ -760,7 +760,8 @@ def fish_modifier_in_notice_cb(data, modifier, server_name, string):
     global fish_DH1080ctx, fish_keys, fish_cyphers
 
     match = re.match(
-        r"^(?:@time=[\d:TZ.-]+\s)?(:(.*?)!.*? NOTICE (.*?) :)((DH1080_INIT |DH1080_INIT_CBC |DH1080_FINISH |\+OK |mcps )?.*)$",
+        r"^((?:@[^ ]* )?:(.*?)!.*? NOTICE (.*?) :)"
+        r"((DH1080_INIT |DH1080_FINISH |\+OK |mcps )?.*)$",
         string)
     #match.group(0): message
     #match.group(1): msg without payload
@@ -850,7 +851,8 @@ def fish_modifier_in_privmsg_cb(data, modifier, server_name, string):
     global fish_keys, fish_cyphers
 
     match = re.match(
-        r"^(?:@time=[\d:TZ.-]+\s)?(:(.*?)!.*? PRIVMSG (.*?) :)(\x01ACTION )?((\+OK |mcps )?.*?)(\x01)?$",
+        r"^((?:@[^ ]* )?:(.*?)!.*? PRIVMSG (.*?) :)(\x01ACTION )?"
+        r"((\+OK |mcps )?.*?)(\x01)?$",
         string)
     #match.group(0): message
     #match.group(1): msg without payload
@@ -898,7 +900,7 @@ def fish_modifier_in_privmsg_cb(data, modifier, server_name, string):
 def fish_modifier_in_topic_cb(data, modifier, server_name, string):
     global fish_keys, fish_cyphers
 
-    match = re.match(r"^(?:@time=[\d:TZ.-]+\s)?(:.*?!.*? TOPIC (.*?) :)((\+OK |mcps )?.*)$", string)
+    match = re.match(r"^((?:@[^ ]* )?:.*?!.*? TOPIC (.*?) :)((\+OK |mcps )?.*)$", string)
     #match.group(0): message
     #match.group(1): msg without payload
     #match.group(2): channel
@@ -933,7 +935,7 @@ def fish_modifier_in_topic_cb(data, modifier, server_name, string):
 def fish_modifier_in_332_cb(data, modifier, server_name, string):
     global fish_keys, fish_cyphers
 
-    match = re.match(r"^(?:@time=[\d:TZ.-]+\s)?(:.*? 332 .*? (.*?) :)((\+OK |mcps )?.*)$", string)
+    match = re.match(r"^((?:@[^ ]* )?:.*? 332 .*? (.*?) :)((\+OK |mcps )?.*)$", string)
     if not match:
         return string
 


### PR DESCRIPTION
Copied the regex from upstream https://github.com/weechat/scripts/commit/05546b4ad34a65907b5cab0daea6f001cfd853aa

This allows for parsing messages that does not only have @time, but also more attributes such as; `@time=2023-08-26T12:53:54.448Z;msgid=594~1692356666~8396;inspircd.org/echo :nick!ident@hosat.tld PRIVMSG......`