### PR TITLE
Add compatibility for ECB/CBC messages on CBC/ECB channels

### DIFF
--- a/fish.py
+++ b/fish.py
@@ -433,11 +433,14 @@ def blowcrypt_unpack(msg, cipher):
 
     if rest[0] == "*":
         if cipher.mode != Blowfish.MODE_CBC:
-            raise ValueError
+            if not bool(cipher.key.decode("utf-8").startswith('cbc:')):
+                key = "cbc:" + cipher.key.decode("utf-8")
+                return blowcrypt_unpack(msg, Blowfish(key))
         raw = rest[1:]
     else:
         if cipher.mode != Blowfish.MODE_ECB:
-            raise ValueError
+            key = cipher.key.decode("utf-8")
+            return blowcrypt_unpack(msg, Blowfish(key))
         if len(rest) < 12:
             raise MalformedError
 

--- a/fish.py
+++ b/fish.py
@@ -451,7 +451,7 @@ def blowcrypt_unpack(msg, cipher, wrong_key_type=False):
 
     if rest[0] == "*":
         if cipher.mode != Blowfish.MODE_CBC:
-            if not bool(cipher.key.decode("utf-8").startswith('cbc:')):
+            if not cipher.key.decode("utf-8").startswith('cbc:'):
                 key = "cbc:" + cipher.key.decode("utf-8")
                 return blowcrypt_unpack(msg, Blowfish(key), wrong_key_type=True)
         raw = rest[1:]
@@ -476,9 +476,6 @@ def blowcrypt_unpack(msg, cipher, wrong_key_type=False):
         plain, broken = cipher.decrypt(raw)
     except ValueError:
         raise MalformedError
-
-    if wrong_key_type:
-        return plain.strip('\x00').replace('\n',''), broken, wrong_key_type
 
     return plain.strip('\x00').replace('\n',''), broken, wrong_key_type
 


### PR DESCRIPTION
* CBC message comes in, key is set to ECB, message will be decrypted successfully. When you send messages it will use the type set, in this scenario ECB.
* ECB message comes in, key is set to CBC, message will be decrypted successfully. When you send messages it will use the type set, in this scenario CBC
* Added announce (on by default) when key type does not match the currently configured.
  * `Message from network/#channel does not match the key type set on this buffer`
  * To dsable the announce: `/set fish.look.announce_wrong_key_type off` and don't forget to `/save`